### PR TITLE
feat: sync teacher weights to policy

### DIFF
--- a/orz/ppo/actors.py
+++ b/orz/ppo/actors.py
@@ -758,6 +758,37 @@ class PolicyRayActorBase(RayActor):
             ray.get(refs)
         torch.distributed.barrier()
 
+    def _init_teacher_policy_group(self, master_address=None, master_port=None, is_teacher=False):
+        """Create a temporary process group between teacher rank0 and policy rank0."""
+        if torch.distributed.get_rank() == 0:
+            if master_address is None and master_port is None:
+                master_address = ray._private.services.get_node_ip_address()
+                with socket.socket() as sock:
+                    sock.bind(("", 0))
+                    master_port = sock.getsockname()[1]
+            backend = getattr(self.strategy.args, "vllm_sync_backend", "nccl")
+            self._teacher_policy_group = orz_init_process_group(
+                backend=backend,
+                init_method=f"tcp://{master_address}:{master_port}",
+                world_size=2,
+                rank=0 if is_teacher else 1,
+                group_name="teacher_policy_sync",
+            )
+            result = (master_address, master_port)
+        else:
+            result = (None, None)
+        torch.distributed.barrier()
+        return result
+
+    def _sync_weights_with_teacher(self):
+        """Broadcast teacher weights to policy through previously created group."""
+        torch.cuda.empty_cache()
+        model = self.model.model.module
+        for _, param in model.named_parameters():
+            with deepspeed.zero.GatheredParameters([param], enabled=self.strategy.args.zero_stage == 3):
+                if torch.distributed.get_rank() == 0:
+                    torch.distributed.broadcast(param.data, src=0, group=self._teacher_policy_group)
+
     def _broadcast_to_vllm(self, vllm_engines):
         # avoid OOM
         torch.cuda.empty_cache()

--- a/orz/ppo/trainer.py
+++ b/orz/ppo/trainer.py
@@ -2004,3 +2004,15 @@ class RayPPOTrainer:
             await self.teacher_model.async_run_method("_broadcast_to_vllm_cudaipc", self.vllm_engines)
         else:
             await self.teacher_model.async_run_method("_broadcast_to_vllm", self.vllm_engines)
+
+    async def _sync_teacher_weights_to_policy(self):
+        """Synchronize teacher weights into policy model using a temporary process group."""
+        addr_port = await self.policy_model.async_run_method("_init_teacher_policy_group")
+        master_addr, master_port = addr_port[0]
+        await self.teacher_model.async_run_method(
+            "_init_teacher_policy_group", master_addr, master_port, True
+        )
+        await asyncio.gather(
+            self.teacher_model.async_run_method("_sync_weights_with_teacher"),
+            self.policy_model.async_run_method("_sync_weights_with_teacher"),
+        )


### PR DESCRIPTION
## Summary
- add process group for syncing teacher weights to policy ranks
- allow trainer to broadcast teacher parameters into policy model

## Testing
- `python -m py_compile orz/ppo/actors.py orz/ppo/trainer.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac6787d5e8832d9bb79515f23d0a5c