### PR TITLE
broadcast policy weights to reference model

### DIFF
--- a/orz/ppo/trainer.py
+++ b/orz/ppo/trainer.py
@@ -183,13 +183,9 @@ class RayPPOTrainer:
 
             if self.cfg.update_ref_every_epoch:
                 await self.policy_model.backload_to_gpu()
+                await self.policy_model.async_run_method("_broadcast_to_ref", self.ref_model._actor_handlers)
                 await self.policy_model.async_save_model(self.tokenizer, self.global_step)
                 await self.policy_model.offload_to_cpu()
-                await asyncio.gather(
-                    *self.ref_model.async_init_model_from_pretrained(
-                        self.strategy, os.path.join(self.cfg.save_path, f"iter{self.global_step}", "policy")
-                    )
-                )
                 logger.info("Successfully update ref model with policy model, training continue.")
 
         await self.policy_model.async_save_model(self.tokenizer, self.cfg.num_episodes * len(self.prompts_dataloader))


### PR DESCRIPTION
## Summary
- Add `_broadcast_to_ref` in policy actor to send parameters directly to reference model
- Implement `update_weight` handler for reference actors
- Use in trainer to sync policy weights with teacher via broadcast each epoch

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acd519ace4832d83f566b12de69038